### PR TITLE
Prepare for publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,6 @@ jobs:
         with:
           path: "repos/dynamic_colors"
 
-      # TODO: Remove when public
-      - uses: actions/checkout@v2
-        with:
-          repository: material-foundation/material-color-utilities
-          token: ${{ secrets.TEMP_PAT }}
-          path: "repos/material-color-utilities"
-
       - name: Install dependencies
         run: flutter pub get
         working-directory: "repos/dynamic_colors"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,21 +29,21 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          path: "repos/dynamic_colors"
+          path: "repos/dynamic_color"
 
       - name: Install dependencies
         run: flutter pub get
-        working-directory: "repos/dynamic_colors"
+        working-directory: "repos/dynamic_color"
 
       - name: Verify formatting
         run: flutter format --dry-run --set-exit-if-changed .
-        working-directory: "repos/dynamic_colors"
+        working-directory: "repos/dynamic_color"
 
       # Consider passing '--fatal-infos' for slightly stricter analysis.
       - name: Analyze project source
         run: flutter analyze
-        working-directory: "repos/dynamic_colors"
+        working-directory: "repos/dynamic_color"
 
       - name: Run tests
         run: flutter test
-        working-directory: "repos/dynamic_colors"
+        working-directory: "repos/dynamic_color"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A Flutter package to obtain dynamic colors on Android S+ and create harmonized
 color schemes.
 
-Learn more about [dynamic color](https://m3.material.io/styles/color/dynamic-color/overview) and [harmonization](https://m3.material.io/styles/color/the-color-system/custom-colors#harmonization) on the Material 3 site.
+Learn more about [dynamic color](https://m3.material.io/styles/color/dynamic-color/overview). and [harmonization](https://m3.material.io/styles/color/the-color-system/custom-colors#harmonization) on the Material 3 site.
 
 ## Features
 
@@ -21,7 +21,7 @@ Under the hood, `DynamicColorBuilder` uses a plugin to talk to the Android OS.
 
 ### Color and color scheme harmonization
 
-How do we ensure any particular color (i.e. semantic or custom color)
+How do we ensure any particular color (i.e. semantic/custom color)
 looks good next to a user's dynamically-generated color?
 
 This package provides two extension methods, `Color.harmonizeWith()` and

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![ci](https://github.com/material-foundation/material-dynamic-color-flutter/actions/workflows/test.yml/badge.svg)](https://github.com/material-foundation/material-dynamic-color-flutter/actions/workflows/test.yml)
 [![pub package](https://img.shields.io/pub/v/dynamic_color.svg)](https://pub.dev/packages/dynamic_color)
 
-A Flutter plugin to obtain dynamic colors on Android S+ and create harmonized
+A Flutter package to obtain dynamic colors on Android S+ and create harmonized
 color schemes.
 
 Learn more about [dynamic color](https://m3.material.io/styles/color/dynamic-color/overview) and [harmonization](https://m3.material.io/styles/color/the-color-system/custom-colors#harmonization) on the Material 3 site.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A Flutter plugin to obtain dynamic colors on Android S+ and create harmonized
 color schemes.
 
-TODO(guidezpl): link to API docs once published
+Learn more about [dynamic color](https://m3.material.io/styles/color/dynamic-color/overview) and [harmonization](https://m3.material.io/styles/color/the-color-system/custom-colors#harmonization) on the Material 3 site.
 
 ## Features
 
@@ -21,7 +21,7 @@ Under the hood, `DynamicColorBuilder` uses a plugin to talk to the Android OS.
 
 ### Color and color scheme harmonization
 
-How do we ensure any particular reserved color (i.e. semantic or brand color)
+How do we ensure any particular color (i.e. semantic or custom color)
 looks good next to a user's dynamically-generated color?
 
 This package provides two extension methods, `Color.harmonizeWith()` and
@@ -32,7 +32,7 @@ color, typically `colorScheme.primary`. This leaves the color recognizable
 while harmonizing it.
 
 `ColorScheme.harmonized()` does the same thing, for all `ColorScheme`'s
-semantic colors. See [harmonization.dart] for more.
+semantic and custom colors. See [harmonization.dart] for more.
 
 ## Getting started
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -94,7 +94,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   material_color_utilities:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -176,7 +176,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.13.4 <3.0.0"
   flutter: ">=1.20.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -98,10 +98,10 @@ packages:
   material_color_utilities:
     dependency: transitive
     description:
-      path: "../../material-color-utilities/dart"
-      relative: true
-    source: path
-    version: "0.1.0"
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   meta:
     dependency: transitive
     description:

--- a/lib/src/harmonization.dart
+++ b/lib/src/harmonization.dart
@@ -20,26 +20,28 @@ extension ColorSchemeHarmonization on ColorScheme {
 
   /// Harmonizes semantic [ColorScheme] colors with its [primary] color.
   ///
-  /// TODO(guidezpl): link to spec
+  /// Harmonization makes adding and introducing new colors to your app more
+  /// seamless by automatically shifting hue and chroma slightly so that a
+  /// product's colors feel more cohesive with user colors.
   ///
-  /// Semantic colors (i.e. colors with meaning) are [error] and [onError]. Not
-  /// harmonizing them would cause semantic colors to look out of place next to
-  /// dynamic colors.
+  /// Semantic colors (i.e. colors with meaning) include [error] and [onError],
+  /// as well as custom colors. See https://m3.material.io/styles/color/the-color-system/custom-colors#harmonization
+  /// for more information.
   ///
-  /// Subclasses of [ColorScheme] with additional semantic colors should
-  /// re-implement [harmonized]. For example:
+  /// Subclasses of [ColorScheme] that add custom colors should re-implement
+  /// [harmonized]. For example:
   /// import 'package:dynamic_color/dynamic_color.dart';
   ///
   /// class CustomColorScheme extends ColorScheme {
-  ///   const CustomColorScheme(this.customSemanticColor) : super(...);
+  ///   const CustomColorScheme(this.customYellow) : super(...);
   ///
-  ///   final Color customSemanticColor;
+  ///   final Color customYellow;
   ///
   ///   CustomColorScheme copyWith({ ... }) {}
   ///
   ///   CustomColorScheme harmonized() {
   ///     return copyWith(
-  ///       customSemanticColor: _harmonizeWithPrimary(customSemanticColor),
+  ///       customYellow: _harmonizeWithPrimary(customYellow),
   ///       error: _harmonizeWithPrimary(error),
   ///       onError: _harmonizeWithPrimary(onError),
   ///     );

--- a/lib/src/harmonization.dart
+++ b/lib/src/harmonization.dart
@@ -24,8 +24,8 @@ extension ColorSchemeHarmonization on ColorScheme {
   /// seamless by automatically shifting hue and chroma slightly so that a
   /// product's colors feel more cohesive with user colors.
   ///
-  /// Semantic colors (i.e. colors with meaning) include [error] and [onError],
-  /// as well as custom colors. See https://m3.material.io/styles/color/the-color-system/custom-colors#harmonization
+  /// Semantic colors (i.e. colors with meaning) include [error] and [onError].
+  /// See https://m3.material.io/styles/color/the-color-system/custom-colors#harmonization
   /// for more information.
   ///
   /// Subclasses of [ColorScheme] that add custom colors should re-implement

--- a/lib/src/harmonization.dart
+++ b/lib/src/harmonization.dart
@@ -18,7 +18,7 @@ extension ColorSchemeHarmonization on ColorScheme {
   /// Harmonizes [color] with this [ColorScheme]'s [primary].
   Color _harmonizeWithPrimary(Color color) => _harmonizeColor(color, primary);
 
-  /// Harmonizes semantic [ColorScheme] colors with its [primary] color.
+  /// Harmonizes semantic and custom [ColorScheme] colors with its [primary] color.
   ///
   /// Harmonization makes adding and introducing new colors to your app more
   /// seamless by automatically shifting hue and chroma slightly so that a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_test:
+    sdk: flutter
   material_color_utilities: ^0.1.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   flutter_lints: ^1.0.0
   meta: ^1.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,6 @@ name: dynamic_color
 description: Flutter plugin to obtain dynamic colors on Android.
 version: 0.1.0
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
-publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,9 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # TODO: use pub.dev when published
-  material_color_utilities:
-    path: ../material-color-utilities/dart
+  material_color_utilities: ^0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dynamic_color
-description: Flutter plugin to obtain dynamic colors on Android.
+description: Flutter package to obtain dynamic colors on Android S+ and create harmonized color schemes.
 version: 0.1.0
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
 


### PR DESCRIPTION
And align README and docs with m3 site.  It only mentions custom colors (will file a bug for that), but since we harmonize semantic colors (e.g. error) I also talk about those. 

Closes material-foundation/flutter-packages#346 
Closes material-foundation/flutter-packages#347