### PR TITLE
Move samples to own library

### DIFF
--- a/lib/samples.dart
+++ b/lib/samples.dart
@@ -1,0 +1,23 @@
+import 'package:dynamic_color/dynamic_color.dart';
+import 'package:flutter/material.dart';
+import 'package:material_color_utilities/material_color_utilities.dart';
+
+/// Sample [CorePalette]s to be used to mock dynamic color in tests & development.
+class SampleCorePalettes {
+  static CorePalette green = CorePalette.of(0xFF575D54);
+  static CorePalette orange = CorePalette.of(0xFF5A545D);
+}
+
+/// Sample [ColorScheme]s to be used in tests & development.
+///
+/// Correspond to the [CorePalette]s in [SampleCorePalettes].
+class SampleColorSchemes {
+  static ColorScheme green(Brightness brightness) =>
+      SampleCorePalettes.green.toColorScheme(
+        brightness: brightness,
+      )!;
+  static ColorScheme orange(Brightness brightness) =>
+      SampleCorePalettes.orange.toColorScheme(
+        brightness: brightness,
+      )!;
+}

--- a/lib/test_utils.dart
+++ b/lib/test_utils.dart
@@ -6,35 +6,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_color_utilities/material_color_utilities.dart';
 
-final sampleOfCorePalette = CorePalette.of(0xFF3F51B5);
-
-final sampleFromListCorePalette = generateCorePalette((i) => i);
-
 /// Generates a [CorePalette] based on some generator function which takes an index.
 CorePalette generateCorePalette(int Function(int index) generator) =>
     CorePalette.fromList(
       List<int>.generate(CorePalette.size * TonalPalette.commonSize, generator),
     );
-
-/// Sample [CorePalette]s to be used to mock dynamic color in tests & development.
-class SampleCorePalettes {
-  static CorePalette green = CorePalette.of(0xFF575D54);
-  static CorePalette orange = CorePalette.of(0xFF5A545D);
-}
-
-/// Sample [ColorScheme]s to be used in tests & development.
-///
-/// Correspond to the [CorePalette]s in [SampleCorePalettes].
-class SampleColorSchemes {
-  static ColorScheme green(Brightness brightness) =>
-      SampleCorePalettes.green.toColorScheme(
-        brightness: brightness,
-      )!;
-  static ColorScheme orange(Brightness brightness) =>
-      SampleCorePalettes.orange.toColorScheme(
-        brightness: brightness,
-      )!;
-}
 
 /// Static methods used for testing apps with dynamic [CorePalette]s.
 class DynamicColorTestingUtils {

--- a/test/dynamic_color_builder_test.dart
+++ b/test/dynamic_color_builder_test.dart
@@ -1,4 +1,5 @@
 import 'package:dynamic_color/dynamic_color.dart';
+import 'package:dynamic_color/samples.dart';
 import 'package:dynamic_color/test_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -7,7 +8,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('DynamicColorBuilder', (WidgetTester tester) async {
-    DynamicColorTestingUtils.setMockDynamicColors(sampleOfCorePalette);
+    DynamicColorTestingUtils.setMockDynamicColors(SampleCorePalettes.green);
 
     const containerKey = Key('myContainer');
 

--- a/test/dynamic_color_plugin_test.dart
+++ b/test/dynamic_color_plugin_test.dart
@@ -6,6 +6,8 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('getCorePalette', () async {
+    final sampleFromListCorePalette = generateCorePalette((i) => i);
+
     DynamicColorTestingUtils.setMockDynamicColors(sampleFromListCorePalette);
     final colors = await DynamicColorPlugin.getCorePalette();
     expect(colors, sampleFromListCorePalette);


### PR DESCRIPTION
Internal code is strict about keeping test-only code separate. Put samples in their own library and refactor other usages