### PR TITLE
Fix harmonization for `onErrorContainer`

### DIFF
--- a/lib/src/harmonization.dart
+++ b/lib/src/harmonization.dart
@@ -55,7 +55,7 @@ extension ColorSchemeHarmonization on ColorScheme {
       error: _harmonizeWithPrimary(error),
       onError: _harmonizeWithPrimary(onError),
       errorContainer: _harmonizeWithPrimary(errorContainer),
-      onErrorContainer: _harmonizeWithPrimary(errorContainer),
+      onErrorContainer: _harmonizeWithPrimary(onErrorContainer),
     );
   }
 }


### PR DESCRIPTION
Fixes material-foundation/flutter-packages#339