### PR TITLE
Fix text overflowed from example

### DIFF
--- a/example/lib/common.dart
+++ b/example/lib/common.dart
@@ -21,7 +21,7 @@ class ColoredSquare extends StatelessWidget {
             color: color,
           ),
           const SizedBox(width: 10),
-          Text(description),
+          Flexible(child: Text(description)),
         ],
       ),
     );


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/26688719/164974336-c3ea026b-6517-4fa0-b255-2fc3a08ae78c.png" width="200">
After:
<img src="https://user-images.githubusercontent.com/26688719/164974343-cdb54c1a-88a1-4790-beb3-e9a0b850bc5a.png" width="200">
 