### PR TITLE
Retrieve macOS accent color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Add support for macOS' control accent color ([#42](https://github.com/material-foundation/material-dynamic-color-flutter/pull/42))
+
 ## 1.2.3
 
 - Tweak pubspec description

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/dynamic_color.svg)](https://pub.dev/packages/dynamic_color)
 
-A Flutter package to obtain and create Material color schemes based on a platform's implementation of dynamic color. Currently supported platforms are:
+A Flutter package to create Material color schemes based on a platform's implementation of dynamic color. Currently supported platforms are:
 - Android S+: [color from user wallpaper](https://m3.material.io/styles/color/dynamic-color/user-generated-color)
 - macOS: [app accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![pub package](https://img.shields.io/pub/v/dynamic_color.svg)](https://pub.dev/packages/dynamic_color)
 
 A Flutter package to create Material color schemes based on a platform's implementation of dynamic color. Currently supported platforms are:
+
 - Android S+: [color from user wallpaper](https://m3.material.io/styles/color/dynamic-color/user-generated-color)
 - macOS: [app accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
 
@@ -17,7 +18,7 @@ that provides the device's dynamic colors in a light and dark `ColorScheme`.
 
 ### Plugin
 
-Under the hood, `DynamicColorBuilder` uses a plugin to talk to the Android OS.
+Under the hood, `DynamicColorBuilder` uses a plugin to talk to the OS.
 
 ### Color and color scheme harmonization
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![pub package](https://img.shields.io/pub/v/dynamic_color.svg)](https://pub.dev/packages/dynamic_color)
 
-A Flutter package to obtain dynamic colors on Android S+ or color accent color in macOS,
-and create harmonized color schemes from them.
+A Flutter package to obtain and create Material color schemes based on a platform's implementation of dynamic color. Currently supported platforms are:
+- Android S+: [color from user wallpaper](https://m3.material.io/styles/color/dynamic-color/user-generated-color)
+- macOS: [app accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
 
-Learn more about [dynamic color](https://m3.material.io/styles/color/dynamic-color/overview), [custom colors and harmonization](https://m3.material.io/styles/color/the-color-system/custom-colors) on the Material 3 site.
+This package also supports color and color scheme harmonization. Learn more about [custom colors and harmonization](https://m3.material.io/styles/color/the-color-system/custom-colors) on the Material 3 site.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![pub package](https://img.shields.io/pub/v/dynamic_color.svg)](https://pub.dev/packages/dynamic_color)
 
-A Flutter package to obtain dynamic colors on Android S+ and create harmonized color schemes.
+A Flutter package to obtain dynamic colors on Android S+ or color accent color in macOS,
+and create harmonized color schemes from them.
 
 Learn more about [dynamic color](https://m3.material.io/styles/color/dynamic-color/overview), [custom colors and harmonization](https://m3.material.io/styles/color/the-color-system/custom-colors) on the Material 3 site.
 

--- a/example/lib/control_accent_color.dart
+++ b/example/lib/control_accent_color.dart
@@ -1,6 +1,6 @@
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:dynamic_color_example/common.dart';
-import 'package:flutter/foundation.dart';
+
 import 'package:flutter/material.dart';
 
 class ControlAccentColorExample extends StatelessWidget {

--- a/example/lib/control_accent_color.dart
+++ b/example/lib/control_accent_color.dart
@@ -1,0 +1,33 @@
+import 'package:dynamic_color/dynamic_color.dart';
+import 'package:dynamic_color_example/common.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class ControlAccentColorExample extends StatelessWidget {
+  const ControlAccentColorExample({Key? key}) : super(key: key);
+
+  static const title = 'Control accent color';
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Color?>(
+      future: DynamicColorPlugin.getControlAccentColor(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          final color = snapshot.data;
+          return color == null
+              ? const Text(
+                  "Control accent color isn't supported on this platform",
+                )
+              : Column(
+                  children: [
+                    ColoredSquare(color, 'Control Accent Color'),
+                  ],
+                );
+        } else {
+          return const CircularProgressIndicator();
+        }
+      },
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'common.dart';
 import 'complete_example.dart';
+import 'control_accent_color.dart';
 import 'core_palette_visualization.dart';
 import 'dynamic_color_builder_example.dart';
 import 'get_core_palette_example.dart';
@@ -42,6 +43,10 @@ class ExampleApp extends StatelessWidget {
                 const _ExampleAppButton(
                   title: CorePaletteVisualization.title,
                   widget: CorePaletteVisualization(),
+                ),
+                const _ExampleAppButton(
+                  title: ControlAccentColorExample.title,
+                  widget: ControlAccentColorExample(),
                 ),
                 const _ExampleAppButton(
                   title: HarmonizationExample.title,

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import dynamic_color
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
 }

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				61FDA41A623D455A08718732 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -310,6 +311,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		61FDA41A623D455A08718732 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.3"
+    version: "1.3.0"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/dynamic_color_builder.dart
+++ b/lib/src/dynamic_color_builder.dart
@@ -58,10 +58,12 @@ class DynamicColorBuilderState extends State<DynamicColorBuilder> {
       // setState to update our non-existent appearance.
       if (!mounted) return;
 
-      setState(() {
-        _light = corePalette?.toColorScheme();
-        _dark = corePalette?.toColorScheme(brightness: Brightness.dark);
-      });
+      if (corePalette != null) {
+        setState(() {
+          _light = corePalette.toColorScheme();
+          _dark = corePalette.toColorScheme(brightness: Brightness.dark);
+        });
+      }
     } on PlatformException {
       debugPrint('Failed to obtain dynamic colors.');
 

--- a/lib/src/dynamic_color_builder.dart
+++ b/lib/src/dynamic_color_builder.dart
@@ -49,27 +49,28 @@ class DynamicColorBuilderState extends State<DynamicColorBuilder> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initPlatformState() async {
-    // If the widget was removed from the tree while the asynchronous platform
-    // message was in flight, we want to discard the reply rather than calling
-    // setState to update our non-existent appearance.
-    if (!mounted) return;
-
-    CorePalette? corePalette;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      corePalette = await DynamicColorPlugin.getCorePalette();
-    } on PlatformException {
-      debugPrint('Failed to obtain dynamic colors.');
-    }
+      CorePalette? corePalette = await DynamicColorPlugin.getCorePalette();
 
-    if (corePalette != null) {
+      // If the widget was removed from the tree while the asynchronous platform
+      // message was in flight, we want to discard the reply rather than calling
+      // setState to update our non-existent appearance.
+      if (!mounted) return;
+
       setState(() {
         _light = corePalette?.toColorScheme();
         _dark = corePalette?.toColorScheme(brightness: Brightness.dark);
       });
-    } else {
+    } on PlatformException {
+      debugPrint('Failed to obtain dynamic colors.');
+
       try {
-        Color color = Color(await DynamicColorPlugin.getControlAccentColor());
+        final color = Color(await DynamicColorPlugin.getControlAccentColor());
+
+        // Likewise above.
+        if (!mounted) return;
+
         setState(() {
           _light = ColorScheme.fromSeed(
             seedColor: color,

--- a/lib/src/dynamic_color_builder.dart
+++ b/lib/src/dynamic_color_builder.dart
@@ -59,7 +59,7 @@ class DynamicColorBuilderState extends State<DynamicColorBuilder> {
       if (!mounted) return;
 
       if (color == null) {
-          debugPrint('Got null core palette.');
+        debugPrint('Got null core palette.');
       } else {
         setState(() {
           _light = corePalette.toColorScheme();
@@ -71,7 +71,8 @@ class DynamicColorBuilderState extends State<DynamicColorBuilder> {
     }
 
     try {
-      final Color? controlAccentColor = await DynamicColorPlugin.getControlAccentColor();
+      final Color? controlAccentColor =
+          await DynamicColorPlugin.getControlAccentColor();
 
       // Likewise above.
       if (!mounted) return;

--- a/lib/src/dynamic_color_builder.dart
+++ b/lib/src/dynamic_color_builder.dart
@@ -66,21 +66,25 @@ class DynamicColorBuilderState extends State<DynamicColorBuilder> {
       debugPrint('Failed to obtain dynamic colors.');
 
       try {
-        final color = Color(await DynamicColorPlugin.getControlAccentColor());
+        final color = await DynamicColorPlugin.getControlAccentColor();
 
         // Likewise above.
         if (!mounted) return;
 
-        setState(() {
-          _light = ColorScheme.fromSeed(
-            seedColor: color,
-            brightness: Brightness.light,
-          );
-          _dark = ColorScheme.fromSeed(
-            seedColor: color,
-            brightness: Brightness.dark,
-          );
-        });
+        if (color == null) {
+          debugPrint('Control accent color result was null.');
+        } else {
+          setState(() {
+            _light = ColorScheme.fromSeed(
+              seedColor: color,
+              brightness: Brightness.light,
+            );
+            _dark = ColorScheme.fromSeed(
+              seedColor: color,
+              brightness: Brightness.dark,
+            );
+          });
+        }
       } on PlatformException {
         debugPrint('Failed to obtain control accent color.');
       }

--- a/lib/src/dynamic_color_builder.dart
+++ b/lib/src/dynamic_color_builder.dart
@@ -7,8 +7,11 @@ import 'dynamic_color_plugin.dart';
 
 /// A stateful builder widget that provides a light and dark [ColorScheme].
 ///
-/// The [ColorScheme]s are constructed from the [CorePalette] provided by the
-/// Android OS.
+/// Android: the [ColorScheme]s are constructed from the [CorePalette] provided
+/// by the Android OS.
+///
+/// macOS: the [ColorScheme]s are constructed from the accent [Color] provided
+/// by macOS.
 ///
 /// See also:
 ///
@@ -17,6 +20,8 @@ import 'dynamic_color_plugin.dart';
 ///    for obtaining dynamic colors and creating a harmonized color scheme
 ///  * [DynamicColorPlugin.getCorePalette] for requesting the [CorePalette]
 ///    directly, asynchronously.
+///  * [DynamicColorPlugin.getControlAccentColor] for requesting the accent [Color]
+///    [ColorScheme] directly, asynchronously.
 class DynamicColorBuilder extends StatefulWidget {
   const DynamicColorBuilder({
     Key? key,
@@ -25,9 +30,8 @@ class DynamicColorBuilder extends StatefulWidget {
 
   /// Builds the child widget of this widget, providing a light and dark [ColorScheme].
   ///
-  /// The [ColorScheme]s will be null if dynamic color is not supported (i.e on
-  /// non-Android platforms and pre-Android S devices), or if the colors
-  /// have yet to be obtained.
+  /// The [ColorScheme]s will be null if dynamic color is not supported on the
+  /// platform, or if the OS has yet to respond.
   final Widget Function(
     ColorScheme? lightDynamic,
     ColorScheme? darkDynamic,
@@ -58,7 +62,7 @@ class DynamicColorBuilderState extends State<DynamicColorBuilder> {
       // setState to update our non-existent appearance.
       if (!mounted) return;
 
-      if (color == null) {
+      if (corePalette == null) {
         debugPrint('Got null core palette.');
       } else {
         setState(() {

--- a/lib/src/dynamic_color_builder.dart
+++ b/lib/src/dynamic_color_builder.dart
@@ -58,38 +58,40 @@ class DynamicColorBuilderState extends State<DynamicColorBuilder> {
       // setState to update our non-existent appearance.
       if (!mounted) return;
 
-      if (corePalette != null) {
+      if (color == null) {
+          debugPrint('Got null core palette.');
+      } else {
         setState(() {
           _light = corePalette.toColorScheme();
           _dark = corePalette.toColorScheme(brightness: Brightness.dark);
         });
       }
     } on PlatformException {
-      debugPrint('Failed to obtain dynamic colors.');
+      debugPrint('Failed to obtain core palette.');
+    }
 
-      try {
-        final color = await DynamicColorPlugin.getControlAccentColor();
+    try {
+      final Color? controlAccentColor = await DynamicColorPlugin.getControlAccentColor();
 
-        // Likewise above.
-        if (!mounted) return;
+      // Likewise above.
+      if (!mounted) return;
 
-        if (color == null) {
-          debugPrint('Control accent color result was null.');
-        } else {
-          setState(() {
-            _light = ColorScheme.fromSeed(
-              seedColor: color,
-              brightness: Brightness.light,
-            );
-            _dark = ColorScheme.fromSeed(
-              seedColor: color,
-              brightness: Brightness.dark,
-            );
-          });
-        }
-      } on PlatformException {
-        debugPrint('Failed to obtain control accent color.');
+      if (controlAccentColor == null) {
+        debugPrint('Got null control accent color.');
+      } else {
+        setState(() {
+          _light = ColorScheme.fromSeed(
+            seedColor: controlAccentColor,
+            brightness: Brightness.light,
+          );
+          _dark = ColorScheme.fromSeed(
+            seedColor: controlAccentColor,
+            brightness: Brightness.dark,
+          );
+        });
       }
+    } on PlatformException {
+      debugPrint('Failed to obtain control accent color.');
     }
   }
 

--- a/lib/src/dynamic_color_plugin.dart
+++ b/lib/src/dynamic_color_plugin.dart
@@ -12,8 +12,10 @@ class DynamicColorPlugin {
     'io.material.plugins/dynamic_color',
   );
 
-  /// The method name that the Kotlin plugin listens for.
+  /// A method name that the Kotlin plugin listens for.
   static const methodName = 'getCorePalette';
+
+  /// A method name that the Kotlin plugin listens for.
   static const controlAccentColorMethodName = 'getControlAccentColor';
 
   /// Returns the Android OS' dynamic colors asynchronously in a [CorePalette].
@@ -30,6 +32,7 @@ class DynamicColorPlugin {
     return result == null ? null : CorePalette.fromList(result.toList());
   }
 
+  /// Returns the macOS' control accent color asynchronously in an [int] color.
   static Future<int> getControlAccentColor() async =>
       await channel.invokeMethod(controlAccentColorMethodName);
 }

--- a/lib/src/dynamic_color_plugin.dart
+++ b/lib/src/dynamic_color_plugin.dart
@@ -33,9 +33,9 @@ class DynamicColorPlugin {
     return result == null ? null : CorePalette.fromList(result.toList());
   }
 
-  /// Returns the macOS' control accent color asynchronously in a [Color].
+  /// Returns the macOS' control accent color asynchronously as a [Color].
   ///
-  /// Supported since macOS 10.14, Mojave
+  /// Supported since macOS 10.14 (Mojave).
   ///
   /// See also:
   ///

--- a/lib/src/dynamic_color_plugin.dart
+++ b/lib/src/dynamic_color_plugin.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flutter/services.dart';
 import 'package:material_color_utilities/material_color_utilities.dart';
@@ -15,7 +16,7 @@ class DynamicColorPlugin {
   /// A method name that the Kotlin plugin listens for.
   static const methodName = 'getCorePalette';
 
-  /// A method name that the Kotlin plugin listens for.
+  /// A method name that the macOS plugin listens for.
   static const controlAccentColorMethodName = 'getControlAccentColor';
 
   /// Returns the Android OS' dynamic colors asynchronously in a [CorePalette].
@@ -32,7 +33,16 @@ class DynamicColorPlugin {
     return result == null ? null : CorePalette.fromList(result.toList());
   }
 
-  /// Returns the macOS' control accent color asynchronously in an [int] color.
-  static Future<int> getControlAccentColor() async =>
-      await channel.invokeMethod(controlAccentColorMethodName);
+  /// Returns the macOS' control accent color asynchronously in a [Color].
+  ///
+  /// Supported since macOS 10.14, Mojave
+  ///
+  /// See also:
+  ///
+  /// * [Apple's introduction to macos accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
+  /// * [NSColor.controlAccentColor documentation](https://developer.apple.com/documentation/appkit/nscolor/3000782-controlaccentcolor)
+  static Future<Color?> getControlAccentColor() async {
+    final result = await channel.invokeMethod(controlAccentColorMethodName);
+    return result == null ? null : Color(result);
+  }
 }

--- a/lib/src/dynamic_color_plugin.dart
+++ b/lib/src/dynamic_color_plugin.dart
@@ -14,6 +14,7 @@ class DynamicColorPlugin {
 
   /// The method name that the Kotlin plugin listens for.
   static const methodName = 'getCorePalette';
+  static const controlAccentColorMethodName = 'getControlAccentColor';
 
   /// Returns the Android OS' dynamic colors asynchronously in a [CorePalette].
   ///
@@ -28,4 +29,7 @@ class DynamicColorPlugin {
     final result = await channel.invokeMethod(methodName);
     return result == null ? null : CorePalette.fromList(result.toList());
   }
+
+  static Future<int> getControlAccentColor() async =>
+      await channel.invokeMethod(controlAccentColorMethodName);
 }

--- a/lib/test_utils.dart
+++ b/lib/test_utils.dart
@@ -16,11 +16,17 @@ CorePalette generateCorePalette(int Function(int index) generator) =>
 class DynamicColorTestingUtils {
   /// Initializes the dynamic color plugin with mock values for testing.
   @visibleForTesting
-  static void setMockDynamicColors(CorePalette? colors) {
+  static void setMockDynamicColors({
+    CorePalette? colors,
+    Color? controlAccentColor,
+  }) {
     DynamicColorPlugin.channel
         .setMockMethodCallHandler((MethodCall methodCall) async {
       if (methodCall.method == DynamicColorPlugin.methodName) {
         return colors != null ? Int64List.fromList(colors.asList()) : null;
+      } else if (methodCall.method ==
+          DynamicColorPlugin.controlAccentColorMethodName) {
+        return controlAccentColor?.value;
       }
     });
     addTearDown(() {

--- a/macos/Classes/DynamicColorPlugin.swift
+++ b/macos/Classes/DynamicColorPlugin.swift
@@ -11,16 +11,20 @@ public class DynamicColorPlugin: NSObject, FlutterPlugin {
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "getControlAccentColor":
-      var nsColor = NSColor.systemBlue
       if #available(macOS 10.14, *) {
-        nsColor = NSColor.controlAccentColor
+        if let color = NSColor.controlAccentColor.usingColorSpace(.sRGB) {
+          var r: CGFloat = 0
+          var g: CGFloat = 0
+          var b: CGFloat = 0
+          var a: CGFloat = 0
+          color.getRed(&r, green: &g, blue: &b, alpha: &a)
+          result(Int(a * 255) << 24 + Int(r * 255) << 16 + Int(g * 255) << 8 + Int(b * 255))
+        } else {
+          result(nil)
+        }
+      } else {
+        result(nil)
       }
-      var r: CGFloat = 0
-      var g: CGFloat = 0
-      var b: CGFloat = 0
-      var a: CGFloat = 0
-      nsColor.usingColorSpace(.sRGB)!.getRed(&r, green: &g, blue: &b, alpha: &a)
-      result(Int(a * 255) << 24 + Int(r * 255) << 16 + Int(g * 255) << 8 + Int(b * 255))
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/macos/Classes/DynamicColorPlugin.swift
+++ b/macos/Classes/DynamicColorPlugin.swift
@@ -1,0 +1,28 @@
+import Cocoa
+import FlutterMacOS
+
+public class DynamicColorPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "io.material.plugins/dynamic_color", binaryMessenger: registrar.messenger)
+    let instance = DynamicColorPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "getControlAccentColor":
+      var nsColor = NSColor.systemBlue
+      if #available(macOS 10.14, *) {
+        nsColor = NSColor.controlAccentColor
+      }
+      var r: CGFloat = 0
+      var g: CGFloat = 0
+      var b: CGFloat = 0
+      var a: CGFloat = 0
+      nsColor.usingColorSpace(.sRGB)!.getRed(&r, green: &g, blue: &b, alpha: &a)
+      result(Int(a * 255) << 24 + Int(r * 255) << 16 + Int(g * 255) << 8 + Int(b * 255))
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}

--- a/macos/dynamic_color.podspec
+++ b/macos/dynamic_color.podspec
@@ -1,5 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'dynamic_color'
+  s.authors          = 'Ebrahim Byagowi'
+  s.license          = 'BSD-3-Clause'
+  s.homepage         = 'https://github.com/material-foundation/material-dynamic-color-flutter'
+  s.summary          = 'Retrieves control accent color'
+  s.version          = '0.0.1'
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'

--- a/macos/dynamic_color.podspec
+++ b/macos/dynamic_color.podspec
@@ -1,0 +1,9 @@
+Pod::Spec.new do |s|
+  s.name             = 'dynamic_color'
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+  s.platform = :osx, '10.11'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.swift_version = '5.0'
+end

--- a/macos/dynamic_color.podspec
+++ b/macos/dynamic_color.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'dynamic_color'
-  s.authors          = 'Ebrahim Byagowi'
+  s.authors          = 'Material Flutter team + Ebrahim Byagowi'
   s.license          = 'BSD-3-Clause'
   s.homepage         = 'https://github.com/material-foundation/material-dynamic-color-flutter'
   s.summary          = 'Retrieves control accent color'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,3 +24,6 @@ flutter:
       android:
         package: io.material.plugins.dynamic_color
         pluginClass: DynamicColorPlugin
+      macos:
+        package: io.material.plugins.dynamic_color
+        pluginClass: DynamicColorPlugin

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_color
-description: A Flutter package to obtain dynamic colors on Android S+ and create harmonized color schemes.
-version: 1.2.3
+description: A Flutter package to create Material color schemes based on a platform's implementation of dynamic color.
+version: 1.3.0
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
 
 environment:

--- a/test/dynamic_color_builder_test.dart
+++ b/test/dynamic_color_builder_test.dart
@@ -8,7 +8,9 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('DynamicColorBuilder', (WidgetTester tester) async {
-    DynamicColorTestingUtils.setMockDynamicColors(SampleCorePalettes.green);
+    DynamicColorTestingUtils.setMockDynamicColors(
+      colors: SampleCorePalettes.green,
+    );
 
     const containerKey = Key('myContainer');
 

--- a/test/dynamic_color_plugin_test.dart
+++ b/test/dynamic_color_plugin_test.dart
@@ -29,7 +29,7 @@ void main() {
     const color = Color.fromARGB(12, 24, 123, 53);
 
     DynamicColorTestingUtils.setMockDynamicColors(
-        controlAccentColor: color,
+      controlAccentColor: color,
     );
     final result = await DynamicColorPlugin.getControlAccentColor();
     expect(result, color);

--- a/test/dynamic_color_plugin_test.dart
+++ b/test/dynamic_color_plugin_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:dynamic_color/test_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,15 +10,35 @@ void main() {
   test('getCorePalette', () async {
     final sampleFromListCorePalette = generateCorePalette((i) => i);
 
-    DynamicColorTestingUtils.setMockDynamicColors(sampleFromListCorePalette);
+    DynamicColorTestingUtils.setMockDynamicColors(
+      colors: sampleFromListCorePalette,
+    );
     final colors = await DynamicColorPlugin.getCorePalette();
     expect(colors, sampleFromListCorePalette);
   });
 
   test('getCorePalette returns null', () async {
-    DynamicColorTestingUtils.setMockDynamicColors(null);
-
+    DynamicColorTestingUtils.setMockDynamicColors(
+      colors: null,
+    );
     final colors = await DynamicColorPlugin.getCorePalette();
+    expect(colors, equals(null));
+  });
+
+  test('getControlAccentColor', () async {
+    const color = Color.fromARGB(12, 24, 123, 53);
+
+    DynamicColorTestingUtils.setMockDynamicColors(
+        controlAccentColor: color,
+    );
+    final result = await DynamicColorPlugin.getControlAccentColor();
+    expect(result, color);
+  });
+
+  test('getControlAccentColor returns null', () async {
+    DynamicColorTestingUtils.setMockDynamicColors(controlAccentColor: null);
+
+    final colors = await DynamicColorPlugin.getControlAccentColor();
     expect(colors, equals(null));
   });
 }


### PR DESCRIPTION
This introduces getControlAccentColor and implements it in macOS.

Fixes material-foundation/flutter-packages#338

Guess some API reimagination would be needed but at least it works I can say,

<img width="803" alt="Screen Shot 2022-05-24 at 6 47 55 PM" src="https://user-images.githubusercontent.com/833473/170057895-6a663935-43b0-4505-b1c8-4855760505ea.png">