### PR TITLE
Implement querying window color from DWM

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -42,7 +42,7 @@ target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 # dependencies here.
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin dwmapi.lib)
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an

--- a/windows/dynamic_color_plugin.cpp
+++ b/windows/dynamic_color_plugin.cpp
@@ -2,6 +2,7 @@
 
 // This must be included before many other Windows headers.
 #include <windows.h>
+#include <dwmapi.h>
 
 // For getPlatformVersion; remove unless needed for your plugin implementation.
 #include <VersionHelpers.h>
@@ -37,27 +38,60 @@ DynamicColorPlugin::DynamicColorPlugin() {}
 
 DynamicColorPlugin::~DynamicColorPlugin() {}
 
+static BOOL GetAccentColorViaRegistry(int64_t& argbColor) {
+  DWORD abgr = 0;
+  DWORD resultSize = sizeof (abgr);
+
+  if (
+    RegGetValue(
+      HKEY_CURRENT_USER,
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Accent",
+      L"AccentColorMenu",
+      RRF_RT_REG_DWORD,
+      nullptr,
+      &abgr,
+      &resultSize
+    ) == S_OK
+  ) {
+    argbColor = (abgr & 0xFF00FF00) + ((abgr & 0xFF) << 16) + ((abgr & 0xFF0000) >> 16);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+static BOOL GetWindowColorViaDwm(int64_t& argbColor) {
+  DWORD color = 0;
+  BOOL opaque = FALSE;
+
+  if (SUCCEEDED(DwmGetColorizationColor(&color, &opaque))) {
+    argbColor = color;
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 void DynamicColorPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   if (!method_call.method_name().compare("getAccentColor")) {
-    int64_t argbColor = 0;
-    DWORD abgr = 0;
-    DWORD resultSize = sizeof (abgr);
-    if (
-      RegGetValue(
-        HKEY_CURRENT_USER,
-        L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Accent",
-        L"AccentColorMenu",
-        RRF_RT_REG_DWORD,
-        nullptr,
-        &abgr,
-        &resultSize
-      ) == S_OK
-    ) {
-      argbColor = (abgr & 0xFF00FF00) + ((abgr & 0xFF) << 16) + ((abgr & 0xFF0000) >> 16);
-      result->Success(flutter::EncodableValue(argbColor));
-    } else result->Success(nullptr);
+    int64_t argb = 0;
+    BOOL successful = FALSE;
+
+    // Try one method after the other until one works
+    if (IsWindows10OrGreater()) {
+      successful = GetAccentColorViaRegistry(argb);
+    }
+    if (!successful && IsWindowsVistaOrGreater()) {
+      successful = GetWindowColorViaDwm(argb);
+    }
+
+    if (successful) {
+      result->Success(flutter::EncodableValue(argb));
+    } else {
+      result->Success(nullptr);
+    }
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
This alternative method of fetching the "user color" makes it possible to support Windows Vista onward. Testing locally on a Windows 7 machine yielded okay-ish results as some values returned by [DwmGetColorizationColor](https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmgetcolorizationcolor) were unrecognizable, but I believe this can be ignored as the Material You color algorithms should be able to still find the correct hue and so on.

Just for fun, in theory it could be possible to support cases where the user doesn't have/use Aero and uses a classic theme/visual style (Windows XP for example), by querying the [legacy system colors](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsyscolor) (like caption background or 3D objects color) which are changed by such theme. But going to this length is a bit unnecessary.

https://user-images.githubusercontent.com/22963120/172486352-b79fa385-1e13-4e41-bf7c-0e40df2dda66.mp4