### PR TITLE
Support for DWM with more accurate colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+- Add support for DWM/Windows Aero's color ([#50](https://github.com/material-foundation/material-dynamic-color-flutter/pull/50))
+
 ## 1.5.0
 
 - Add support for GTK's accent color on Linux ([#47](https://github.com/material-foundation/material-dynamic-color-flutter/pull/47))

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Flutter package to create Material color schemes based on a platform's impleme
 - Android S+: [color from user wallpaper](https://m3.material.io/styles/color/dynamic-color/user-generated-color)
 - Linux: GTK+ theme's `@theme_selected_bg_color`
 - macOS: [app accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
-- Windows: [accent color](https://docs.microsoft.com/en-us/windows/apps/design/style/color#accent-color)
+- Windows: [accent](https://docs.microsoft.com/en-us/windows/apps/design/style/color#accent-color) and [window/glass](https://web.archive.org/web/20080812195923/http://www.microsoft.com/windows/windows-vista/features/aero.aspx?tabid=2&catid=4) color
 
 This package also supports color and color scheme harmonization.
 

--- a/lib/src/dynamic_color_plugin.dart
+++ b/lib/src/dynamic_color_plugin.dart
@@ -35,14 +35,15 @@ class DynamicColorPlugin {
 
   /// Returns the OS' accent color asynchronously as a [Color].
   ///
-  /// Supported on macOS starting with 10.14 (Mojave), on Windows with
-  /// Windows 10, and on GTK-based Linux desktops.
+  /// Supported on macOS starting with 10.14 (Mojave), on Windows starting with
+  /// Vista, and on GTK-based Linux desktops.
   ///
   /// See also:
   ///
   /// * [Apple's introduction to macOS accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
   /// * [macOS's NSColor.controlAccentColor documentation](https://developer.apple.com/documentation/appkit/nscolor/3000782-controlaccentcolor)
   /// * [Windows' accent color](https://docs.microsoft.com/en-us/windows/apps/design/style/color#accent-color)
+  /// * [Windows Aero](https://web.archive.org/web/20080812195923/http://www.microsoft.com/windows/windows-vista/features/aero.aspx?tabid=2&catid=4)
   /// * [Change colors in Windows](https://support.microsoft.com/en-us/windows/change-colors-in-windows-d26ef4d6-819a-581c-1581-493cfcc005fe)
   static Future<Color?> getAccentColor() async {
     final result = await channel.invokeMethod(accentColorMethodName);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_color
 description: A Flutter package to create Material color schemes based on a platform's implementation of dynamic color.
-version: 1.5.0
+version: 1.5.1
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
 
 environment:

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -42,7 +42,7 @@ target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 # dependencies here.
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin dwmapi.lib)
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 # This list could contain prebuilt libraries, or libraries created by an

--- a/windows/dwm.c
+++ b/windows/dwm.c
@@ -1,0 +1,14 @@
+#include <windows.h>
+
+typedef struct COLORIZATIONPARAMS
+{
+    COLORREF clrColor;
+    COLORREF clrAftGlow;
+    UINT nIntensity;
+    UINT clrAftGlowBal;
+    UINT clrBlurBal;
+    UINT clrGlassReflInt;
+    BOOL fOpaque;
+} COLORIZATIONPARAMS;
+
+HRESULT (WINAPI *DwmGetColorizationParameters) (COLORIZATIONPARAMS *colorparam);

--- a/windows/dynamic_color_plugin.cpp
+++ b/windows/dynamic_color_plugin.cpp
@@ -2,6 +2,7 @@
 
 // This must be included before many other Windows headers.
 #include <windows.h>
+#include <dwmapi.h>
 
 // For getPlatformVersion; remove unless needed for your plugin implementation.
 #include <VersionHelpers.h>
@@ -37,27 +38,60 @@ DynamicColorPlugin::DynamicColorPlugin() {}
 
 DynamicColorPlugin::~DynamicColorPlugin() {}
 
+static BOOL GetAccentColorViaRegistry(int64_t& argbColor) {
+  DWORD abgr = 0;
+  DWORD resultSize = sizeof (abgr);
+
+  if (
+    RegGetValue(
+      HKEY_CURRENT_USER,
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Accent",
+      L"AccentColorMenu",
+      RRF_RT_REG_DWORD,
+      nullptr,
+      &abgr,
+      &resultSize
+    ) == S_OK
+  ) {
+    argbColor = (abgr & 0xFF00FF00) + ((abgr & 0xFF) << 16) + ((abgr & 0xFF0000) >> 16);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+static BOOL GetWindowColorViaDwm(int64_t& argbColor) {
+  DWORD color = 0;
+  BOOL opaque = FALSE;
+
+  if (SUCCEEDED(DwmGetColorizationColor(&color, &opaque))) {
+    argbColor = color;
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 void DynamicColorPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   if (!method_call.method_name().compare("getAccentColor")) {
-    int64_t argbColor = 0;
-    DWORD abgr = 0;
-    DWORD resultSize = sizeof (abgr);
-    if (
-      RegGetValue(
-        HKEY_CURRENT_USER,
-        L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Accent",
-        L"AccentColorMenu",
-        RRF_RT_REG_DWORD,
-        nullptr,
-        &abgr,
-        &resultSize
-      ) == S_OK
-    ) {
-      argbColor = (abgr & 0xFF00FF00) + ((abgr & 0xFF) << 16) + ((abgr & 0xFF0000) >> 16);
-      result->Success(flutter::EncodableValue(argbColor));
-    } else result->Success(nullptr);
+    int64_t argb = 0;
+    BOOL successful = FALSE;
+
+    // Try one method after the other until one works
+    if (IsWindows10OrGreater()) {
+      successful = GetAccentColorViaRegistry(argb);
+    }
+    if (!successful && IsWindowsVistaOrGreater()) {
+      successful = GetWindowColorViaDwm(argb);
+    }
+
+    if (successful) {
+      result->Success(flutter::EncodableValue(argb));
+    } else {
+      result->Success(nullptr);
+    }
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
As discussed in #48, I have made use of the alternative method of interfacing with DWM. Using the undocumented function `GetColorizationParameters` and the equivalent registry keys `HKCU\Software\Microsoft\Windows\DWM` to fetch the correct window color before it goes through "Aero treatment" (something).