### PR TITLE
Make return value of toColorScheme extension method non-nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.5
+
+- Make return value of toColorScheme extension method non-nullable ([#55](https://github.com/material-foundation/material-dynamic-color-flutter/pull/55))
+
 ## 1.5.4
 
 - Update constraint for Flutter SDK

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.5.5"
   fake_async:
     dependency: transitive
     description:

--- a/lib/samples.dart
+++ b/lib/samples.dart
@@ -15,9 +15,9 @@ class SampleColorSchemes {
   static ColorScheme green(Brightness brightness) =>
       SampleCorePalettes.green.toColorScheme(
         brightness: brightness,
-      )!;
+      );
   static ColorScheme orange(Brightness brightness) =>
       SampleCorePalettes.orange.toColorScheme(
         brightness: brightness,
-      )!;
+      );
 }

--- a/lib/src/corepalette_to_colorscheme.dart
+++ b/lib/src/corepalette_to_colorscheme.dart
@@ -3,7 +3,7 @@ import 'package:material_color_utilities/material_color_utilities.dart';
 
 extension CorePaletteToColorScheme on CorePalette {
   /// Create a [ColorScheme] from the given `palette` obtained from the Android OS.
-  ColorScheme? toColorScheme({
+  ColorScheme toColorScheme({
     Brightness brightness = Brightness.light,
   }) {
     final Scheme scheme;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_color
 description: A Flutter package to create Material color schemes based on a platform's implementation of dynamic color.
-version: 1.5.5
+version: 1.5.4
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_color
 description: A Flutter package to create Material color schemes based on a platform's implementation of dynamic color.
-version: 1.5.4
+version: 1.5.5
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
 
 environment:


### PR DESCRIPTION
It never returns `null`, so using nullable type is not necessary.