### PR TITLE
Support for outlineVariant and scrim color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.5.5
 
+- Add support for `outlineVariant` and `scrim` colors
 - Update constraint for `material_color_utilities` to `0.2.0`
 - Update Flutter constraint
 

--- a/lib/src/corepalette_to_colorscheme.dart
+++ b/lib/src/corepalette_to_colorscheme.dart
@@ -34,6 +34,7 @@ extension CorePaletteToColorScheme on CorePalette {
       errorContainer: Color(scheme.errorContainer),
       onErrorContainer: Color(scheme.onErrorContainer),
       outline: Color(scheme.outline),
+      outlineVariant: Color(scheme.outlineVariant),
       background: Color(scheme.background),
       onBackground: Color(scheme.onBackground),
       surface: Color(scheme.surface),
@@ -44,6 +45,7 @@ extension CorePaletteToColorScheme on CorePalette {
       onInverseSurface: Color(scheme.inverseOnSurface),
       inversePrimary: Color(scheme.inversePrimary),
       shadow: Color(scheme.shadow),
+      scrim: Color(scheme.scrim),
       brightness: brightness,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_color
 description: A Flutter package to create Material color schemes based on a platform's implementation of dynamic color.
-version: 1.5.4
+version: 1.5.5
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
 
 environment:


### PR DESCRIPTION
Fixes material-foundation/flutter-packages#333 

We are missing the outlineVariant and scrim color. And in material3 we use outlineVariant for Dividers. 

So, Added outlineVariant and scrim color.