### PR TITLE
Add support for Android Q+ accent color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Update Flutter constraint
 - Make return value of toColorScheme extension method non-nullable ([#55](https://github.com/material-foundation/material-dynamic-color-flutter/pull/55))
 
+## 1.5.5
+
+- Add support for Android Q+ accent color support ([#61](https://github.com/material-foundation/material-dynamic-color-flutter/pull/61)).
+
 ## 1.5.4
 
 - Update constraint for Flutter SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-## NEXT
+## 1.5.5
 
 - Update constraint for `material_color_utilities` to `0.2.0`
 - Update Flutter constraint
 - Make return value of toColorScheme extension method non-nullable ([#55](https://github.com/material-foundation/material-dynamic-color-flutter/pull/55))
-
-## 1.5.5
-
 - Add support for Android Q+ accent color support ([#61](https://github.com/material-foundation/material-dynamic-color-flutter/pull/61)).
 
 ## 1.5.4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Flutter package to create Material color schemes based on a platform's implementation of dynamic color. Currently supported platforms are:
 
-- Android S+: [color from user wallpaper](https://m3.material.io/styles/color/dynamic-color/user-generated-color)
+- Android: [color from user wallpaper (S+)](https://m3.material.io/styles/color/dynamic-color/user-generated-color) or system accent color (Q+)
 - Linux: GTK+ theme's `@theme_selected_bg_color`
 - macOS: [app accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
 - Windows: [accent color](https://docs.microsoft.com/en-us/windows/apps/design/style/color#accent-color) or [window/glass color](https://web.archive.org/web/20080812195923/http://www.microsoft.com/windows/windows-vista/features/aero.aspx?tabid=2&catid=4)

--- a/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
+++ b/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
@@ -1,11 +1,9 @@
 package io.material.plugins.dynamic_color
 
-import android.content.Context
 import android.content.res.Resources
 import android.content.res.TypedArray
 import android.os.Build
 import androidx.annotation.ColorInt
-import androidx.annotation.NonNull
 import androidx.annotation.RequiresApi
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
@@ -24,15 +22,13 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
 
   private lateinit var binding: FlutterPluginBinding
 
-  override fun onAttachedToEngine(
-    @NonNull flutterPluginBinding: FlutterPluginBinding
-  ) {
+  override fun onAttachedToEngine(flutterPluginBinding: FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "io.material.plugins/dynamic_color")
     channel.setMethodCallHandler(this)
     this.binding = flutterPluginBinding
   }
 
-  override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+  override fun onMethodCall(call: MethodCall, result: Result) {
     if (call.method.equals("getCorePalette")) {
       // Dynamic colors are only available on Android S and up.
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -43,7 +39,8 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
       }
     } else if (call.method.equals("getAccentColor")) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        result.success(getAccentColor(binding.applicationContext))
+        val theme: Resources.Theme = binding.applicationContext.theme
+        result.success(getAccentColor(theme))
       } else {
         result.success(null)
       }
@@ -52,19 +49,19 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
     }
   }
 
-  override fun onDetachedFromEngine(@NonNull binding: FlutterPluginBinding) {
+  override fun onDetachedFromEngine(binding: FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
   }
 
   @RequiresApi(Build.VERSION_CODES.Q)
-  private fun getAccentColor(@NonNull context: Context): Int {
-    val array : TypedArray = context.obtainStyledAttributes(
-      android.R.style.TextAppearance_DeviceDefault,
+  private fun getAccentColor(theme: Resources.Theme): Int {
+    val array : TypedArray = theme.obtainStyledAttributes(
+      android.R.style.Theme_DeviceDefault,
       IntArray(1){android.R.attr.colorAccent},
-    );
-    @ColorInt val color = array.getColor(0, 0);
-    array.recycle();
-    return color;
+    )
+    @ColorInt val color = array.getColor(0, 0)
+    array.recycle()
+    return color
   }
 
   @RequiresApi(Build.VERSION_CODES.S)

--- a/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
+++ b/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
@@ -1,16 +1,19 @@
 package io.material.plugins.dynamic_color
 
+import android.content.Context
+import android.content.res.Resources
+import android.content.res.TypedArray
+import android.os.Build
+import androidx.annotation.ColorInt
 import androidx.annotation.NonNull
-
+import androidx.annotation.RequiresApi
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import android.content.res.Resources
-import android.os.Build
-import androidx.annotation.RequiresApi
-import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
+
 
 class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
   /// The MethodChannel that will the communication between Flutter and native Android
@@ -38,6 +41,10 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
       } else {
         result.success(null)
       }
+    } else if (call.method.equals("getAccentColor")) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        result.success(getAccentColor(binding.applicationContext))
+      }
     } else {
       result.notImplemented()
     }
@@ -45,6 +52,17 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+  }
+
+  @RequiresApi(Build.VERSION_CODES.Q)
+  private fun getAccentColor(@NonNull context: Context): Int {
+    val array : TypedArray = context.obtainStyledAttributes(
+      android.R.style.TextAppearance_DeviceDefault,
+      IntArray(1){android.R.attr.colorAccent},
+    );
+    @ColorInt val color = array.getColor(0, 0);
+    array.recycle();
+    return color;
   }
 
   @RequiresApi(Build.VERSION_CODES.S)

--- a/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
+++ b/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
@@ -44,6 +44,8 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
     } else if (call.method.equals("getAccentColor")) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         result.success(getAccentColor(binding.applicationContext))
+      } else {
+        result.success(null)
       }
     } else {
       result.notImplemented()

--- a/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
+++ b/android/src/main/kotlin/io/material/plugins/dynamic_color/DynamicColorPlugin.kt
@@ -1,5 +1,6 @@
 package io.material.plugins.dynamic_color
 
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.content.res.TypedArray
 import android.os.Build
@@ -39,8 +40,9 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
       }
     } else if (call.method.equals("getAccentColor")) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val resources: Resources = binding.applicationContext.resources
         val theme: Resources.Theme = binding.applicationContext.theme
-        result.success(getAccentColor(theme))
+        result.success(getAccentColor(resources, theme))
       } else {
         result.success(null)
       }
@@ -54,11 +56,17 @@ class DynamicColorPlugin : FlutterPlugin, MethodCallHandler {
   }
 
   @RequiresApi(Build.VERSION_CODES.Q)
-  private fun getAccentColor(theme: Resources.Theme): Int {
+  private fun getAccentColor(resources: Resources, theme: Resources.Theme): Int {
+    val resId = when (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) {
+      Configuration.UI_MODE_NIGHT_YES -> android.R.style.Theme_DeviceDefault
+      else -> android.R.style.Theme_DeviceDefault_Light
+    }
+
     val array : TypedArray = theme.obtainStyledAttributes(
-      android.R.style.Theme_DeviceDefault,
+      resId,
       IntArray(1){android.R.attr.colorAccent},
     )
+
     @ColorInt val color = array.getColor(0, 0)
     array.recycle()
     return color

--- a/example/lib/accent_color.dart
+++ b/example/lib/accent_color.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 class AccentColorExample extends StatelessWidget {
   const AccentColorExample({Key? key}) : super(key: key);
 
-  static const title = 'Accent color (desktop)';
+  static const title = 'Accent color';
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_color
 description: A Flutter package to create Material color schemes based on a platform's implementation of dynamic color.
-version: 1.5.4
+version: 1.5.5
 repository: https://github.com/material-foundation/material-dynamic-color-flutter
 
 environment:


### PR DESCRIPTION
Surprisingly enough, users **can** choose a custom system color before Android 12. There is no proper public documentation about this, nor is it really advertised. However, you can still fetch the accent color. I have made use from the snippet at https://issuetracker.google.com/issues/133641706

| Styles app | Example app |
| - | - |
| ![Screenshot_20230116-195840](https://user-images.githubusercontent.com/22963120/212752119-5d049b8a-2eff-431e-b5bf-63e2d63c7595.png) | ![Screenshot_20230116-195850](https://user-images.githubusercontent.com/22963120/212752167-948e2186-4ca6-404d-a354-b0674d36e36f.png) |
| ![Screenshot_20230116-195918](https://user-images.githubusercontent.com/22963120/212752211-9181926a-4948-47af-9aa5-c61bb6771dfd.png) | ![Screenshot_20230116-195914](https://user-images.githubusercontent.com/22963120/212752248-ced17670-9d18-4137-baf9-07d6e305d947.png) |
| ![Screenshot_20230116-195952](https://user-images.githubusercontent.com/22963120/212752343-a8b82a69-0725-4ad6-9645-d9f785da9dbf.png) | ![Screenshot_20230116-200003](https://user-images.githubusercontent.com/22963120/212752359-365f209e-fe85-436e-ab32-6daf5de000b5.png) |
 

